### PR TITLE
Fix Error in /utility/structure.

### DIFF
--- a/DiscussionPolls/class.discussionpolls.plugin.php
+++ b/DiscussionPolls/class.discussionpolls.plugin.php
@@ -581,7 +581,7 @@ class DiscussionPolls extends Gdn_Plugin {
   /**
    * Setup database structure for model
    */
-  protected function Structure() {
+  public function Structure() {
     $Database = Gdn::Database();
     $Construct = $Database->Structure();
 


### PR DESCRIPTION
Fix the error: `the "DiscussionPolls" object does not have a "xStructure" method` when the plugin is enabled and when viewing /utility/structure.
