### PR TITLE
Always return if DP_Attach field is not set

### DIFF
--- a/DiscussionPolls/class.discussionpolls.plugin.php
+++ b/DiscussionPolls/class.discussionpolls.plugin.php
@@ -402,8 +402,8 @@ class DiscussionPolls extends Gdn_Plugin {
       if($DPModel->Exists($DiscussionID)) {
         Gdn::Controller()->InformMessage(T('Plugins.DiscussionPolls.PollRemoved', 'The attached poll has been removed'));
         $DPModel->DeleteByDiscussionID($DiscussionID);
-        return FALSE;
       }
+      return FALSE;
     }
 
     if($DPModel->Exists($DiscussionID)) {


### PR DESCRIPTION
This fixes an error, where an empty poll is saved when splitting a discussion if "Disable poll titles" is enabled.
